### PR TITLE
add version num

### DIFF
--- a/templates/site.yml.mustache
+++ b/templates/site.yml.mustache
@@ -93,7 +93,7 @@ npms: []
 composers:
   - hirak/prestissimo:*
   - phpunit/phpunit:*
-  - squizlabs/php_codesniffer:*
+  - squizlabs/php_codesniffer:~2.0
   - wp-coding-standards/wpcs:*
   # - phpmd/phpmd:*
   # - sebastian/phpcpd:*


### PR DESCRIPTION
Added php_codesniffer version number.
Because phpcs is faild to install.

Like https://github.com/vccw-team/vccw/commit/c5ebeb273677134cec91ab43811177c42be51176.
The error message is below.
"changed: [wptest.dev] => (item=squizlabs/php_codesniffer:*)
...ignoring
failed: [wptest.dev] (item=wp-coding-standards/wpcs:*) => {"failed": true, "item": "wp-coding-standards/wpcs:*", "msg": "./composer.json has been updated Loading composer repositories with package information Updating dependencies (including require-dev) Your requirements could not be resolved to an installable set of packages. Problem 1 - Conclusion: remove squizlabs/php_codesniffer 3.0.1 - Conclusion: don't install squizlabs/php_codesniffer 3.0.1 - wp-coding-standards/wpcs 0.3.0 requires squizlabs/php_codesniffer ~2.0 -> satisfiable by squizlabs/php_codesniffer[2.0.0, 2.1.0, 2.2.0, 2.3.0, 2.3.1, 2.3.2, 2.3.3, 2.3.4, 2.4.0, 2.5.0, 2.5.1, 2.6.0, 2.6.1, 2.6.2, 2.7.0, 2.7.1, 2.8.0, 2.8.1, 2.9.0, 2.9.1]. - wp-coding-standards/wpcs 0.4.0 requires squizlabs/php_codesniffer ~2.0 -> satisfiable by squizlabs/php_codesniffer[2.0.0, 2.1.0, 2.2.0, 2.3.0, 2.3.1, 2.3.2, 2.3.3, 2.3.4, 2.4.0, 2.5.0, 2.5.1, 2.6.0, 2.6.1, 2.6.2, 2.7.0, 2.7.1, 2.8.0, 2.8.1, 2.9.0, 2.9.1]. - wp-coding-standards/wpcs 0.5.0 requires squizlabs/php_codesniffer ~2.2 -> satisfiable by squizlabs/php_codesniffer[2.2.0, 2.3.0, 2.3.1, 2.3.2, 2.3.3, 2.3.4, 2.4.0, 2.5.0, 2.5.1, 2.6.0, 2.6.1, 2.6.2, 2.7.0, 2.7.1, 2.8.0, 2.8.1, 2.9.0, 2.9.1]. - wp-coding-standards/wpcs 0.6.0 requires squizlabs/php_codesniffer ~2.2 -> satisfiable by squizlabs/php_codesniffer[2.2.0, 2.3.0, 2.3.1, 2.3.2, 2.3.3, 2.3.4, 2.4.0, 2.5.0, 2.5.1, 2.6.0, 2.6.1, 2.6.2, 2.7.0, 2.7.1, 2.8.0, 2.8.1, 2.9.0, 2.9.1]. - wp-coding-standards/wpcs 0.7.0 requires squizlabs/php_codesniffer ~2.2 -> satisfiable by squizlabs/php_codesniffer[2.2.0, 2.3.0, 2.3.1, 2.3.2, 2.3.3, 2.3.4, 2.4.0, 2.5.0, 2.5.1, 2.6.0, 2.6.1, 2.6.2, 2.7.0, 2.7.1, 2.8.0, 2.8.1, 2.9.0, 2.9.1]. - wp-coding-standards/wpcs 0.7.1 requires squizlabs/php_codesniffer ~2.2 -> satisfiable by squizlabs/php_codesniffer[2.2.0, 2.3.0, 2.3.1, 2.3.2, 2.3.3, 2.3.4, 2.4.0, 2.5.0, 2.5.1, 2.6.0, 2.6.1, 2.6.2, 2.7.0, 2.7.1, 2.8.0, 2.8.1, 2.9.0, 2.9.1]. - wp-coding-standards/wpcs 0.8.0 requires squizlabs/php_codesniffer ~2.2 -> satisfiable by squizlabs/php_codesniffer[2.2.0, 2.3.0, 2.3.1, 2.3.2, 2.3.3, 2.3.4, 2.4.0, 2.5.0, 2.5.1, 2.6.0, 2.6.1, 2.6.2, 2.7.0, 2.7.1, 2.8.0, 2.8.1, 2.9.0, 2.9.1]. - wp-coding-standards/wpcs 0.9.0 requires squizlabs/php_codesniffer ~2.2 -> satisfiable by squizlabs/php_codesniffer[2.2.0, 2.3.0, 2.3.1, 2.3.2, 2.3.3, 2.3.4, 2.4.0, 2.5.0, 2.5.1, 2.6.0, 2.6.1, 2.6.2, 2.7.0, 2.7.1, 2.8.0, 2.8.1, 2.9.0, 2.9.1]. - wp-coding-standards/wpcs 0.10.0 requires squizlabs/php_codesniffer ^2.6 -> satisfiable by squizlabs/php_codesniffer[2.6.0, 2.6.1, 2.6.2, 2.7.0, 2.7.1, 2.8.0, 2.8.1, 2.9.0, 2.9.1]. - wp-coding-standards/wpcs 0.11.0 requires squizlabs/php_codesniffer ^2.8.1 -> satisfiable by squizlabs/php_codesniffer[2.8.1, 2.9.0, 2.9.1]. - Can only install one of: squizlabs/php_codesniffer[2.0.0, 3.0.1]. - Can only install one of: squizlabs/php_codesniffer[2.1.0, 3.0.1]. - Can only install one of: squizlabs/php_codesniffer[2.2.0, 3.0.1]. - Can only install one of: squizlabs/php_codesniffer[2.3.0, 3.0.1]. - Can only install one of: squizlabs/php_codesniffer[2.3.1, 3.0.1]. - Can only install one of: squizlabs/php_codesniffer[2.3.2, 3.0.1]. - Can only install one of: squizlabs/php_codesniffer[2.3.3, 3.0.1]. - Can only install one of: squizlabs/php_codesniffer[2.3.4, 3.0.1]. - Can only install one of: squizlabs/php_codesniffer[2.4.0, 3.0.1]. - Can only install one of: squizlabs/php_codesniffer[2.5.0, 3.0.1]. - Can only install one of: squizlabs/php_codesniffer[2.5.1, 3.0.1]. - Can only install one of: squizlabs/php_codesniffer[2.6.0, 3.0.1]. - Can only install one of: squizlabs/php_codesniffer[2.6.1, 3.0.1]. - Can only install one of: squizlabs/php_codesniffer[2.6.2, 3.0.1]. - Can only install one of: squizlabs/php_codesniffer[2.7.0, 3.0.1]. - Can only install one of: squizlabs/php_codesniffer[2.7.1, 3.0.1]. - Can only install one of: squizlabs/php_codesniffer[2.8.0, 3.0.1]. - Can only install one of: squizlabs/php_codesniffer[2.8.1, 3.0.1]. - Can only install one of: squizlabs/php_codesniffer[2.9.0, 3.0.1]. - Can only install one of: squizlabs/php_codesniffer[2.9.1, 3.0.1]. - Installation request for squizlabs/php_codesniffer (locked at 3.0.1, required as *) -> satisfiable by squizlabs/php_codesniffer[3.0.1]. - Installation request for wp-coding-standards/wpcs * -> satisfiable by wp-coding-standards/wpcs[0.10.0, 0.11.0, 0.3.0, 0.4.0, 0.5.0, 0.6.0, 0.7.0, 0.7.1, 0.8.0, 0.9.0]. Installation failed, reverting ./composer.json to its original content.", "stdout": "./composer.json has been updated\nLoading composer repositories with package information\nUpdating dependencies (including require-dev)\nYour requirements could not be resolved to an installable set of packages.\n\n  Problem 1\n    - Conclusion: remove squizlabs/php_codesniffer 3.0.1\n    - Conclusion: don't install squizlabs/php_codesniffer 3.0.1\n    - wp-coding-standards/wpcs 0.3.0 requires squizlabs/php_codesniffer ~2.0 -> satisfiable by squizlabs/php_codesniffer[2.0.0, 2.1.0, 2.2.0, 2.3.0, 2.3.1, 2.3.2, 2.3.3, 2.3.4, 2.4.0, 2.5.0, 2.5.1, 2.6.0, 2.6.1, 2.6.2, 2.7.0, 2.7.1, 2.8.0, 2.8.1, 2.9.0, 2.9.1].\n    - wp-coding-standards/wpcs 0.4.0 requires squizlabs/php_codesniffer ~2.0 -> satisfiable by squizlabs/php_codesniffer[2.0.0, 2.1.0, 2.2.0, 2.3.0, 2.3.1, 2.3.2, 2.3.3, 2.3.4, 2.4.0, 2.5.0, 2.5.1, 2.6.0, 2.6.1, 2.6.2, 2.7.0, 2.7.1, 2.8.0, 2.8.1, 2.9.0, 2.9.1].\n    - wp-coding-standards/wpcs 0.5.0 requires squizlabs/php_codesniffer ~2.2 -> satisfiable by squizlabs/php_codesniffer[2.2.0, 2.3.0, 2.3.1, 2.3.2, 2.3.3, 2.3.4, 2.4.0, 2.5.0, 2.5.1, 2.6.0, 2.6.1, 2.6.2, 2.7.0, 2.7.1, 2.8.0, 2.8.1, 2.9.0, 2.9.1].\n    - wp-coding-standards/wpcs 0.6.0 requires squizlabs/php_codesniffer ~2.2 -> satisfiable by squizlabs/php_codesniffer[2.2.0, 2.3.0, 2.3.1, 2.3.2, 2.3.3, 2.3.4, 2.4.0, 2.5.0, 2.5.1, 2.6.0, 2.6.1, 2.6.2, 2.7.0, 2.7.1, 2.8.0, 2.8.1, 2.9.0, 2.9.1].\n    - wp-coding-standards/wpcs 0.7.0 requires squizlabs/php_codesniffer ~2.2 -> satisfiable by squizlabs/php_codesniffer[2.2.0, 2.3.0, 2.3.1, 2.3.2, 2.3.3, 2.3.4, 2.4.0, 2.5.0, 2.5.1, 2.6.0, 2.6.1, 2.6.2, 2.7.0, 2.7.1, 2.8.0, 2.8.1, 2.9.0, 2.9.1].\n    - wp-coding-standards/wpcs 0.7.1 requires squizlabs/php_codesniffer ~2.2 -> satisfiable by squizlabs/php_codesniffer[2.2.0, 2.3.0, 2.3.1, 2.3.2, 2.3.3, 2.3.4, 2.4.0, 2.5.0, 2.5.1, 2.6.0, 2.6.1, 2.6.2, 2.7.0, 2.7.1, 2.8.0, 2.8.1, 2.9.0, 2.9.1].\n    - wp-coding-standards/wpcs 0.8.0 requires squizlabs/php_codesniffer ~2.2 -> satisfiable by squizlabs/php_codesniffer[2.2.0, 2.3.0, 2.3.1, 2.3.2, 2.3.3, 2.3.4, 2.4.0, 2.5.0, 2.5.1, 2.6.0, 2.6.1, 2.6.2, 2.7.0, 2.7.1, 2.8.0, 2.8.1, 2.9.0, 2.9.1].\n    - wp-coding-standards/wpcs 0.9.0 requires squizlabs/php_codesniffer ~2.2 -> satisfiable by squizlabs/php_codesniffer[2.2.0, 2.3.0, 2.3.1, 2.3.2, 2.3.3, 2.3.4, 2.4.0, 2.5.0, 2.5.1, 2.6.0, 2.6.1, 2.6.2, 2.7.0, 2.7.1, 2.8.0, 2.8.1, 2.9.0, 2.9.1].\n    - wp-coding-standards/wpcs 0.10.0 requires squizlabs/php_codesniffer ^2.6 -> satisfiable by squizlabs/php_codesniffer[2.6.0, 2.6.1, 2.6.2, 2.7.0, 2.7.1, 2.8.0, 2.8.1, 2.9.0, 2.9.1].\n    - wp-coding-standards/wpcs 0.11.0 requires squizlabs/php_codesniffer ^2.8.1 -> satisfiable by squizlabs/php_codesniffer[2.8.1, 2.9.0, 2.9.1].\n    - Can only install one of: squizlabs/php_codesniffer[2.0.0, 3.0.1].\n    - Can only install one of: squizlabs/php_codesniffer[2.1.0, 3.0.1].\n    - Can only install one of: squizlabs/php_codesniffer[2.2.0, 3.0.1].\n    - Can only install one of: squizlabs/php_codesniffer[2.3.0, 3.0.1].\n    - Can only install one of: squizlabs/php_codesniffer[2.3.1, 3.0.1].\n    - Can only install one of: squizlabs/php_codesniffer[2.3.2, 3.0.1].\n    - Can only install one of: squizlabs/php_codesniffer[2.3.3, 3.0.1].\n    - Can only install one of: squizlabs/php_codesniffer[2.3.4, 3.0.1].\n    - Can only install one of: squizlabs/php_codesniffer[2.4.0, 3.0.1].\n    - Can only install one of: squizlabs/php_codesniffer[2.5.0, 3.0.1].\n    - Can only install one of: squizlabs/php_codesniffer[2.5.1, 3.0.1].\n    - Can only install one of: squizlabs/php_codesniffer[2.6.0, 3.0.1].\n    - Can only install one of: squizlabs/php_codesniffer[2.6.1, 3.0.1].\n    - Can only install one of: squizlabs/php_codesniffer[2.6.2, 3.0.1].\n    - Can only install one of: squizlabs/php_codesniffer[2.7.0, 3.0.1].\n    - Can only install one of: squizlabs/php_codesniffer[2.7.1, 3.0.1].\n    - Can only install one of: squizlabs/php_codesniffer[2.8.0, 3.0.1].\n    - Can only install one of: squizlabs/php_codesniffer[2.8.1, 3.0.1].\n    - Can only install one of: squizlabs/php_codesniffer[2.9.0, 3.0.1].\n    - Can only install one of: squizlabs/php_codesniffer[2.9.1, 3.0.1].\n    - Installation request for squizlabs/php_codesniffer (locked at 3.0.1, required as *) -> satisfiable by squizlabs/php_codesniffer[3.0.1].\n    - Installation request for wp-coding-standards/wpcs * -> satisfiable by wp-coding-standards/wpcs[0.10.0, 0.11.0, 0.3.0, 0.4.0, 0.5.0, 0.6.0, 0.7.0, 0.7.1, 0.8.0, 0.9.0].\n\n\nInstallation failed, reverting ./composer.json to its original content.\n", "stdout_lines": ["./composer.json has been updated", "Loading composer repositories with package information", "Updating dependencies (including require-dev)", "Your requirements could not be resolved to an installable set of packages.", "", "  Problem 1", "    - Conclusion: remove squizlabs/php_codesniffer 3.0.1", "    - Conclusion: don't install squizlabs/php_codesniffer 3.0.1", "    - wp-coding-standards/wpcs 0.3.0 requires squizlabs/php_codesniffer ~2.0 -> satisfiable by squizlabs/php_codesniffer[2.0.0, 2.1.0, 2.2.0, 2.3.0, 2.3.1, 2.3.2, 2.3.3, 2.3.4, 2.4.0, 2.5.0, 2.5.1, 2.6.0, 2.6.1, 2.6.2, 2.7.0, 2.7.1, 2.8.0, 2.8.1, 2.9.0, 2.9.1].", "    - wp-coding-standards/wpcs 0.4.0 requires squizlabs/php_codesniffer ~2.0 -> satisfiable by squizlabs/php_codesniffer[2.0.0, 2.1.0, 2.2.0, 2.3.0, 2.3.1, 2.3.2, 2.3.3, 2.3.4, 2.4.0, 2.5.0, 2.5.1, 2.6.0, 2.6.1, 2.6.2, 2.7.0, 2.7.1, 2.8.0, 2.8.1, 2.9.0, 2.9.1].", "    - wp-coding-standards/wpcs 0.5.0 requires squizlabs/php_codesniffer ~2.2 -> satisfiable by squizlabs/php_codesniffer[2.2.0, 2.3.0, 2.3.1, 2.3.2, 2.3.3, 2.3.4, 2.4.0, 2.5.0, 2.5.1, 2.6.0, 2.6.1, 2.6.2, 2.7.0, 2.7.1, 2.8.0, 2.8.1, 2.9.0, 2.9.1].", "    - wp-coding-standards/wpcs 0.6.0 requires squizlabs/php_codesniffer ~2.2 -> satisfiable by squizlabs/php_codesniffer[2.2.0, 2.3.0, 2.3.1, 2.3.2, 2.3.3, 2.3.4, 2.4.0, 2.5.0, 2.5.1, 2.6.0, 2.6.1, 2.6.2, 2.7.0, 2.7.1, 2.8.0, 2.8.1, 2.9.0, 2.9.1].", "    - wp-coding-standards/wpcs 0.7.0 requires squizlabs/php_codesniffer ~2.2 -> satisfiable by squizlabs/php_codesniffer[2.2.0, 2.3.0, 2.3.1, 2.3.2, 2.3.3, 2.3.4, 2.4.0, 2.5.0, 2.5.1, 2.6.0, 2.6.1, 2.6.2, 2.7.0, 2.7.1, 2.8.0, 2.8.1, 2.9.0, 2.9.1].", "    - wp-coding-standards/wpcs 0.7.1 requires squizlabs/php_codesniffer ~2.2 -> satisfiable by squizlabs/php_codesniffer[2.2.0, 2.3.0, 2.3.1, 2.3.2, 2.3.3, 2.3.4, 2.4.0, 2.5.0, 2.5.1, 2.6.0, 2.6.1, 2.6.2, 2.7.0, 2.7.1, 2.8.0, 2.8.1, 2.9.0, 2.9.1].", "    - wp-coding-standards/wpcs 0.8.0 requires squizlabs/php_codesniffer ~2.2 -> satisfiable by squizlabs/php_codesniffer[2.2.0, 2.3.0, 2.3.1, 2.3.2, 2.3.3, 2.3.4, 2.4.0, 2.5.0, 2.5.1, 2.6.0, 2.6.1, 2.6.2, 2.7.0, 2.7.1, 2.8.0, 2.8.1, 2.9.0, 2.9.1].", "    - wp-coding-standards/wpcs 0.9.0 requires squizlabs/php_codesniffer ~2.2 -> satisfiable by squizlabs/php_codesniffer[2.2.0, 2.3.0, 2.3.1, 2.3.2, 2.3.3, 2.3.4, 2.4.0, 2.5.0, 2.5.1, 2.6.0, 2.6.1, 2.6.2, 2.7.0, 2.7.1, 2.8.0, 2.8.1, 2.9.0, 2.9.1].", "    - wp-coding-standards/wpcs 0.10.0 requires squizlabs/php_codesniffer ^2.6 -> satisfiable by squizlabs/php_codesniffer[2.6.0, 2.6.1, 2.6.2, 2.7.0, 2.7.1, 2.8.0, 2.8.1, 2.9.0, 2.9.1].", "    - wp-coding-standards/wpcs 0.11.0 requires squizlabs/php_codesniffer ^2.8.1 -> satisfiable by squizlabs/php_codesniffer[2.8.1, 2.9.0, 2.9.1].", "    - Can only install one of: squizlabs/php_codesniffer[2.0.0, 3.0.1].", "    - Can only install one of: squizlabs/php_codesniffer[2.1.0, 3.0.1].", "    - Can only install one of: squizlabs/php_codesniffer[2.2.0, 3.0.1].", "    - Can only install one of: squizlabs/php_codesniffer[2.3.0, 3.0.1].", "    - Can only install one of: squizlabs/php_codesniffer[2.3.1, 3.0.1].", "    - Can only install one of: squizlabs/php_codesniffer[2.3.2, 3.0.1].", "    - Can only install one of: squizlabs/php_codesniffer[2.3.3, 3.0.1].", "    - Can only install one of: squizlabs/php_codesniffer[2.3.4, 3.0.1].", "    - Can only install one of: squizlabs/php_codesniffer[2.4.0, 3.0.1].", "    - Can only install one of: squizlabs/php_codesniffer[2.5.0, 3.0.1].", "    - Can only install one of: squizlabs/php_codesniffer[2.5.1, 3.0.1].", "    - Can only install one of: squizlabs/php_codesniffer[2.6.0, 3.0.1].", "    - Can only install one of: squizlabs/php_codesniffer[2.6.1, 3.0.1].", "    - Can only install one of: squizlabs/php_codesniffer[2.6.2, 3.0.1].", "    - Can only install one of: squizlabs/php_codesniffer[2.7.0, 3.0.1].", "    - Can only install one of: squizlabs/php_codesniffer[2.7.1, 3.0.1].", "    - Can only install one of: squizlabs/php_codesniffer[2.8.0, 3.0.1].", "    - Can only install one of: squizlabs/php_codesniffer[2.8.1, 3.0.1].", "    - Can only install one of: squizlabs/php_codesniffer[2.9.0, 3.0.1].", "    - Can only install one of: squizlabs/php_codesniffer[2.9.1, 3.0.1].", "    - Installation request for squizlabs/php_codesniffer (locked at 3.0.1, required as *) -> satisfiable by squizlabs/php_codesniffer[3.0.1].", "    - Installation request for wp-coding-standards/wpcs * -> satisfiable by wp-coding-standards/wpcs[0.10.0, 0.11.0, 0.3.0, 0.4.0, 0.5.0, 0.6.0, 0.7.0, 0.7.1, 0.8.0, 0.9.0].", "", "", "Installation failed, reverting ./composer.json to its original content."]}"