### PR TITLE
comment out line that won't be necessary #6

### DIFF
--- a/templates/site.yml.mustache
+++ b/templates/site.yml.mustache
@@ -103,5 +103,5 @@ composers:
 #
 # wp-cli package commands
 #
-wp_cli_packages:
-  - vccw/wp-cli-scaffold-movefile:@stable
+# wp_cli_packages:
+#   - https://github.com/vccw-team/wp-cli-scaffold-movefile/archive/master.zip


### PR DESCRIPTION
these lines for wp-cli package, which should inherit default.yml
..at the same time, update wp-cli-scaffold-movefile repository